### PR TITLE
Added plan-schema flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file. This change
 Added
 - *TBD*
 
+### [0.2.10] - 2016-10-17
+
+Changes
+- Allow plan-schema to be more flexible
+  https://github.com/dollabs/planviz/issues/24
+- Fixed: Planviz disagrees with Pamela (plan-schema)
+  https://github.com/dollabs/pamela/issues/18
+- Added command line switch --strict to enforce schema checking
+- Expand home in pathnames properly
+- Updated dependencies
+
 ### [0.2.9] - 2016-09-29
 
 Changes

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 ;; the file LICENSE at the root of this distribution.
 
 (def project 'dollabs/plan-schema)
-(def version "0.2.9")
+(def version "0.2.10")
 (def description "Temporal Planning Network schema utilities")
 (def project-url "https://github.com/dollabs/plan-schema")
 (def main 'plan-schema.cli)
@@ -33,7 +33,7 @@
                     [crisptrutski/boot-cljs-test "0.2.2-SNAPSHOT" :scope "test"]
                     [adzerk/bootlaces "0.1.13" :scope "test"]
                     ;; api docs
-                    [boot-codox "0.10.0" :scope "test"]
+                    [boot-codox "0.10.1" :scope "test"]
                     ])
 
 (require


### PR DESCRIPTION
Allow plan-schema to be more flexible
  https://github.com/dollabs/planviz/issues/24
Fixed: Planviz disagrees with Pamela (plan-schema)
  https://github.com/dollabs/pamela/issues/18
Added command line switch --strict to enforce schema checking
Expand home in pathnames properly
Updated dependencies

Signed-off-by: Tom Marble tmarble@info9.net
