### PR TITLE
Updated schema for recent PAMELA grammar changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project will be documented in this file. This change
 Added
 - *TBD*
 
+### [0.2.11] - 2016-10-24
+
+Changes
+- Updated schema for recent PAMELA grammar changes
+  https://github.com/dollabs/planviz/issues/24
+- Removes non-PAMELA slots and attributes from the schema checks
+  (which, if found, will fail in --strict mode).
+- Improved the plan-schema launcher (will use jar if present)
+
 ### [0.2.10] - 2016-10-17
 
 Changes
@@ -101,4 +110,5 @@ Added
 [0.2.3]: https://github.com/dollabs/plan-schema/compare/0.2.2...0.2.3
 [0.2.4]: https://github.com/dollabs/plan-schema/compare/0.2.3...0.2.4
 [0.2.10]: https://github.com/dollabs/plan-schema/compare/0.2.4...0.2.10
-[Unreleased]: https://github.com/dollabs/plan-schema/compare/0.2.10...HEAD
+[0.2.11]: https://github.com/dollabs/plan-schema/compare/0.2.10...0.2.11
+[Unreleased]: https://github.com/dollabs/plan-schema/compare/0.2.11...HEAD

--- a/bin/plan-schema
+++ b/bin/plan-schema
@@ -12,8 +12,13 @@ dir=$(dirname $0)
 export PLAN_SCHEMA_CWD="$(pwd -P)"
 cd "$dir"
 cd ..
-top="."
-
+top="$(pwd -P)"
+jar="$top/target/$(ls -1 target | grep 'jar$')"
+clojure_file="$top/target/clojure.cp"
+mainclj_file="$top/target/main.clj"
+LEIN_JVM_OPTS="${LEIN_JVM_OPTS:--server}"
+JVM_OPTS="${JVM_OPTS:-$LEIN_JVM_OPTS}"
+PLAN_SCHEMA_OPTS="${PLAN_SCHEMA_OPTS:-$JVM_OPTS}"
 verbose=0
 
 # functions ------------------------------------------
@@ -44,12 +49,31 @@ case "$1" in
         ;;
 esac
 
-# vlog "-- starting $program at $(date) --"
-
 # ensure plan-schema does not use PAGER to guess we are in the repl
 unset PAGER
 
-vlog "-- starting $program at $(date) --"
 args="$@"
-vlog boot run -a "\"$args\""
-boot run -a "$args"
+vlog "-- starting $program at $(date) --"
+if [ -e "$jar" ]; then
+    vlog "-- using jar: $jar --"
+    NULL_DEVICE=/dev/null
+    if [ -e "$clojure_file" ]; then
+        clojure="$(cat "$clojure_file")"
+    else
+        clojure="$(boot show --classpath | tr '[:]' '\n' | grep 'clojure-[0-9].*.*.jar')"
+        echo "$clojure" > "$clojure_file"
+    fi
+    if [ -e "$mainclj_file" ]; then
+        mainclj="$(cat "$mainclj_file")"
+    else
+        mainclj="(use $(awk '/^\(def main/ { print $3;}' < build.boot)(apply -main *command-line-args*)"
+        echo "$mainclj" > "$mainclj_file"
+    fi
+    vlog java $PLAN_SCHEMA_OPTS -cp "$clojure":"$jar" clojure.main -e "$mainclj" $NULL_DEVICE $args
+    exec java $PLAN_SCHEMA_OPTS -cp "$clojure":"$jar" clojure.main -e "$mainclj" $NULL_DEVICE $args
+else
+    vlog "-- using boot: not using jar --"
+    jar=""
+    vlog boot run -a "\"$args\""
+    boot run -a "$args"
+fi

--- a/bin/test-plan-schema
+++ b/bin/test-plan-schema
@@ -1,0 +1,133 @@
+#!/bin/sh
+# test-plan-schema
+#
+# Copyright © 2016 Dynamic Object Language Labs Inc.
+#
+# This software is licensed under the terms of the
+# Apache License, Version 2.0 which can be found in
+# the file LICENSE at the root of this distribution.
+
+set -e
+
+program=$(basename $0)
+dir=$(dirname $0)
+cd "$dir"
+cd ..
+top="$(pwd -P)"
+verbose=0
+
+# functions ------------------------------------------
+log() {
+  # do NOT log now
+  # echo $* >> "$logfile"
+  echo $*
+}
+
+vlog() {
+    [ $verbose -eq 0 ] || log "$@"
+}
+
+vvlog() {
+    [ $verbose -lt 2 ] || log "$@"
+}
+
+err() {
+  # as log only echos we do not need to repeat this here
+  # log "${program}: $*"
+  echo >&2 "${program}: $*"
+}
+
+# main program -----------------------------------------------
+case "$1" in
+    (-v|-vv|-vvv|-vvvv|--verbose)
+        verbose=$(( $verbose + 1 ))
+        ;;
+esac
+
+# vlog "-- starting $program at $(date) --"
+
+# ensure plan-schema does not use PAGER to guess we are in the repl
+unset PAGER
+
+jar="$top/target/$(ls -1 target | grep  'jar$' | head -1)"
+jar="${jar%.jar}.jar"
+plan_schema="$top/bin/plan-schema"
+results="$top/target/$program"
+pamela_top="$top/../pamela"
+vlog "-- starting $program at $(date) --"
+if [ $verbose -eq 0 ]; then
+    v=""
+    log_level=""
+else
+    v="-v -v"
+    log_level="-l trace"
+fi
+if [ -d "$pamela_top" ]; then
+    cd "$pamela_top"
+    pamela_top="$(pwd -P)"
+    pamela_src="$pamela_top/src/test/pamela"
+    pamela="$pamela_top/bin/pamela"
+    cd "$top"
+else
+    err "cannot find PAMELA in a sibling directory"
+    exit 1
+fi
+
+pamela_jar="$pamela_top/target/uberjar/pamela.jar"
+export PAMELA_MODE=prod # use the jar
+if [ ! -e "$pamela_jar" ]; then
+    vlog "-- building pamela jar --"
+    cd "$pamela_top"
+    lein prod
+    cd "$top"
+fi
+if [ ! -e "$jar" ]; then
+    vlog "-- building plan-schema jar --"
+    boot build
+fi
+mkdir -p "$results"
+# vlog "-- smoke-test 1 --"
+# time $plan_schema $v $log_level -h
+# vlog "-- smoke-test 2 --"
+# time $plan_schema $v -h
+vlog "-- using PAMELA examples from $pamela_top --"
+
+example="tpn-mixed"
+input="$pamela_src/$example.pamela"
+tpn="$results/$example.tpn.edn"
+output="$results/$example.edn"
+vlog "-- $example --"
+vlog $pamela $v $log_level -i "$input" -o "$tpn" tpn
+$pamela $v $log_level -i "$input" -o "$tpn" tpn
+vlog $plan_schema $v --strict -i "$tpn" -o "$output" tpn
+$plan_schema $v --strict -i "$tpn" -o "$output" tpn
+
+example="biased-coin"
+input="$pamela_src/$example.pamela"
+tpn="$results/$example.tpn.edn"
+output="$results/$example.edn"
+vlog "-- $example --"
+vlog $pamela $v $log_level -i "$input" -o "$tpn" "-c" "main:coin:flip-sequence" tpn
+$pamela $v $log_level -i "$input" -o "$tpn" "-c" "main:coin:flip-sequence" tpn
+vlog $plan_schema $v --strict -i "$tpn" -o "$output" tpn
+$plan_schema $v --strict -i "$tpn" -o "$output" tpn
+
+example="lvar-examples"
+input="$pamela_src/$example.pamela"
+tpn="$results/$example.tpn.edn"
+output="$results/$example.edn"
+vlog "-- $example --"
+vlog $pamela $v $log_level -i "$input" -o "$tpn" "-c" "example:imager:main" tpn
+$pamela $v $log_level -i "$input" -o "$tpn" "-c" "example:imager:main" tpn
+vlog $plan_schema $v --strict -i "$tpn" -o "$output" tpn
+$plan_schema $v --strict -i "$tpn" -o "$output" tpn
+
+# example="edgect"
+# tpn="~/src/lispmachine/pamela/planviz-models/edgect.tpn.json"
+# output="$results/$example.edn"
+# vlog "-- $example --"
+# # NOTE fails with --strict
+# # vlog $plan_schema $v --strict -i "$tpn" -o "$output" tpn
+# # $plan_schema $v --strict -i "$tpn" -o "$output" tpn
+# vlog $plan_schema $v -i "$tpn" -o "$output" tpn
+# $plan_schema $v -i "$tpn" -o "$output" tpn

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 ;; the file LICENSE at the root of this distribution.
 
 (def project 'dollabs/plan-schema)
-(def version "0.2.10")
+(def version "0.2.11")
 (def description "Temporal Planning Network schema utilities")
 (def project-url "https://github.com/dollabs/plan-schema")
 (def main 'plan-schema.cli)

--- a/src/plan_schema/core.cljc
+++ b/src/plan_schema/core.cljc
@@ -38,7 +38,6 @@
   (:strict @configuration))
 
 (defn set-strict! [strict]
-  ;; (if (and (not (strict?)) strict)
   (swap! configuration assoc :strict strict))
 
 ;; log-fn should take variable arity
@@ -164,8 +163,7 @@
   "A temporal constraint"
   {:type eq-lvar?
    :name s/Str
-   (s/optional-key :default) bounds
-   })
+   (s/optional-key :default) bounds})
 
 (def check-lvar (s/checker lvar))
 
@@ -219,8 +217,7 @@
    :end-node s/Keyword
    (s/optional-key :between) between
    (s/optional-key :between-ends) between
-   (s/optional-key :between-starts) between
-   })
+   (s/optional-key :between-starts) between})
 
 (def check-temporal-constraint (s/checker temporal-constraint))
 
@@ -311,7 +308,6 @@
    (s/optional-key :controllable) s/Bool
    (s/optional-key :htn-node) s/Keyword
    ;; htn-node points to htn-primitive-task or htn-expanded-nonprimitive-task
-   (s/optional-key :network-flows) #{s/Keyword}
    (s/optional-key :plant) s/Str
    (s/optional-key :plantid) s/Str
    (s/optional-key :command) s/Str
@@ -358,35 +354,6 @@
    })
 
 (def check-delay-activity (s/checker delay-activity))
-
-(s/defschema flow-characteristics
-  "Flow Characteristics"
-  {s/Keyword s/Any})
-
-(defn network-flow? [x]
-  (and (map? x)
-    (#{:network-flow
-       "network-flow"
-       "NETWORK-FLOW"} (get x :tpn-type))))
-
-(s/defschema eq-network-flow?
-  "eq-network-flow?"
-  (s/conditional
-    keyword? (s/eq :network-flow)
-    #(and (string? %)
-       (= "network-flow" (string/lower-case %))) s/Keyword
-    'eq-network-flow?))
-
-(s/defschema network-flow
-  "An network-flow"
-  {:tpn-type eq-network-flow?
-   :uid s/Keyword
-   :start-enclave s/Keyword
-   :end-enclaves #{s/Keyword}
-   :qos-attributes s/Any ;; FIXME
-   :flow-characteristics flow-characteristics})
-
-(def check-network-flow (s/checker network-flow))
 
 (defn null-activity? [x]
   (and (map? x)
@@ -609,7 +576,6 @@
     activity? activity
     null-activity? null-activity
     delay-activity? delay-activity
-    network-flow? network-flow
     state? state
     c-begin? c-begin
     c-end? c-end


### PR DESCRIPTION
Closes #9
Removes non-PAMELA slots and attributes from the schema checks
  (which, if found, will fail in --strict mode).
Improved the plan-schema launcher (will use jar if present)

Signed-off-by: Tom Marble tmarble@info9.net
