### PR TITLE
Fixes for constraints and CLJC

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 ;; the file LICENSE at the root of this distribution.
 
 (def project 'dollabs/plan-schema)
-(def version "0.2.14")
+(def version "0.2.15")
 (def description "Temporal Planning Network schema utilities")
 (def project-url "https://github.com/dollabs/plan-schema")
 (def main 'plan-schema.cli)
@@ -14,7 +14,7 @@
   :resource-paths #{"src"}
   :source-paths   #{"test"}
   :dependencies   '[[org.clojure/clojure         "1.8.0"   :scope "provided"]
-                    [org.clojure/clojurescript   "1.9.293" :scope "provided"]
+                    [org.clojure/clojurescript   "1.9.456" :scope "provided"]
                     [environ                     "1.1.0"]
                     [org.clojure/tools.cli       "0.3.5"]
                     [prismatic/schema            "1.1.3"]
@@ -25,16 +25,16 @@
                     [com.cemerick/piggieback     "0.2.1"          :scope "test"]
                     [weasel                      "0.7.0"          :scope "test"]
                     [org.clojure/tools.nrepl     "0.2.12"         :scope "test"]
-                    [adzerk/boot-reload          "0.4.13"         :scope "test"]
+                    [adzerk/boot-reload          "0.5.1"          :scope "test"]
                     [pandeiro/boot-http          "0.7.6"          :scope "test"]
                     [adzerk/boot-cljs            "1.7.228-2"      :scope "test"]
                     [adzerk/boot-cljs-repl       "0.3.3"          :scope "test"]
                     ;; testing/development
-                    [adzerk/boot-test            "1.1.2"          :scope "test"]
+                    [adzerk/boot-test            "1.2.0"          :scope "test"]
                     [crisptrutski/boot-cljs-test "0.3.0-SNAPSHOT" :scope "test"]
                     [adzerk/bootlaces            "0.1.13"         :scope "test"]
                     ;; api docs
-                    [boot-codox                  "0.10.2"         :scope "test"]
+                    [boot-codox                  "0.10.3"         :scope "test"]
                     ])
 
 (require

--- a/src/plan_schema/core.cljc
+++ b/src/plan_schema/core.cljc
@@ -375,6 +375,7 @@
   {:tpn-type eq-null-activity?
    :uid s/Keyword
    :end-node s/Keyword
+   (s/optional-key :constraints) #{s/Keyword}
    (s/optional-key :label) s/Keyword  ;; label for between
    (s/optional-key :probability) s/Num
    (s/optional-key :cost) s/Num
@@ -891,11 +892,13 @@
                  (read-json-str data)
                  #?(:clj (read-string data)
                     :cljs "not implemented yet")))
+        ;; _ (println "DEBUG DATA\n" (with-out-str (pprint data)))
         result (if (:error data)
                  data
                  (if (= network-type :htn)
                    (coerce-htn data)
                    (coerce-tpn data)))
+        ;; _ (println "DEBUG RESULT\n" (with-out-str (pprint result)))
         out (if (:error result)
               result
               (if (su/error? result)
@@ -1016,7 +1019,9 @@
       conj plid-id)
     (when-not (empty? edges)
       (doseq [edge edges]
-        (add-htn-edge plans plan-id network-plid-id edge plid-id net)))
+        ;; workaround schema coercion problem
+        (let [edge-id (if (keyword? edge) edge (keyword edge))]
+          (add-htn-edge plans plan-id network-plid-id edge-id plid-id net))))
     nil))
 
 ;; nil on success

--- a/test/testing/plan_schema/core.cljc
+++ b/test/testing/plan_schema/core.cljc
@@ -6,18 +6,22 @@
 
 (ns testing.plan-schema.core
   (:require [clojure.string :as string]
-    #?(:clj
-            [clojure.test :refer [deftest testing is]]
-       :cljs [cljs.test :as test :refer-macros [deftest testing is]])
-            [plan-schema.core :as pschema]
-            [plan-schema.cli :as cli]
-            [clojure.pprint :refer :all]
             [clojure.data :as data]
+            #?(:clj
+               [clojure.test :refer [deftest testing is]]
+               :cljs
+               [cljs.test :as test :refer-macros [deftest testing is]])
+            #?(:clj [clojure.pprint :refer [pprint]]
+               :cljs [cljs.pprint :refer [pprint float?]])
+            [plan-schema.core :as pschema]
+            #?(:clj [plan-schema.cli :as cli])
             ))
 
 (deftest working-directory
   (testing "Current Working Directory"
-    (println "Current working directory:" (System/getProperty "user.dir"))))
+    (println "Current working directory:"
+      #?(:clj (System/getProperty "user.dir")
+         :cljs "."))))
 
 ; Pair of files in edn and json format that should match when read by plan schema
 (def test-files [["test/data/main.htn.edn" "test/data/main.htn.json" :htn]
@@ -25,31 +29,36 @@
 
 (defn execute-action [cwd in-file out-file file-format]
   (let [options {:cwd cwd :input in-file :output out-file :file-format file-format}
-        action (get cli/actions (name file-format))]
+        action #?(:clj (get cli/actions (name file-format))
+                  :cljs identity)]
     ;(println "options" options)
     ;(println "action" action)
     ;(println "file-format" file-format)
     (action options)))
 
-(deftest test-schema-reading
-  (testing "JSON Coercion test")
-  (doseq [files test-files]
-    (let [[edn json file-format] files
-          parsed-edn (str edn ".clj")
-          parsed-json (str json ".clj")
-          cwd (System/getProperty "user.dir")
-          out-edn (execute-action cwd edn "-" file-format)
-          out-json (execute-action cwd json "-" file-format)
-          [in-edn in-json in-both] (data/diff out-edn out-json)
-          ]
+#?(:clj
 
-      (println "file set" edn json file-format)
+   (deftest test-schema-reading
+     (testing "JSON Coercion test")
+     (doseq [files test-files]
+       (let [[edn json file-format] files
+             parsed-edn (str edn ".clj")
+             parsed-json (str json ".clj")
+             cwd (System/getProperty "user.dir")
+             out-edn (execute-action cwd edn "-" file-format)
+             out-json (execute-action cwd json "-" file-format)
+             [in-edn in-json in-both] (data/diff out-edn out-json)
+             ]
 
-      (when-not (= out-edn out-json)
-        (println "Files differ" parsed-edn parsed-json)
-        (spit parsed-edn (with-out-str (pprint out-edn)))
-        (spit parsed-json (with-out-str (pprint out-json)))
-        (is false (prn-str "Files differ" parsed-edn parsed-json))))))
+         (println "file set" edn json file-format)
+
+         (when-not (= out-edn out-json)
+           (println "Files differ" parsed-edn parsed-json)
+           (spit parsed-edn (with-out-str (pprint out-edn)))
+           (spit parsed-json (with-out-str (pprint out-json)))
+           (is false (prn-str "Files differ" parsed-edn parsed-json))))))
+
+   )
 
 (deftest test-json
   (testing "test json"


### PR DESCRIPTION
Updated version to 0.2.15

build.boot
- Updated dependencies

core.cljc
- Added workaround for the schema coercion problem
- the schema definition for null-activity had omitted constraints
- Fixed CLJC problems in test/testing/plan_schema/core.cljc

Signed-off-by: Tom Marble <tmarble@info9.net>