### PR TITLE
Updates for 0.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file. This change
 Changes
 * _TBD_
 
+### [0.2.18] - 2017-04-03
+
+Changes
+* Reverted boot-cljs back to "1.7.228-2" to avoid JDK 8 dependency.
+  * Closes #26
+* Removed superfluous debugging messages
+  * Closes PLANVIZ # 80 state end-node
+
 ### [0.2.17] - 2017-03-22
 
 Changes
@@ -161,4 +169,5 @@ Added
 [0.2.15]: https://github.com/dollabs/plan-schema/compare/0.2.14...0.2.15
 [0.2.16]: https://github.com/dollabs/plan-schema/compare/0.2.15...0.2.16
 [0.2.17]: https://github.com/dollabs/plan-schema/compare/0.2.16...0.2.17
-[Unreleased]: https://github.com/dollabs/plan-schema/compare/0.2.17...HEAD
+[0.2.18]: https://github.com/dollabs/plan-schema/compare/0.2.17...0.2.18
+[Unreleased]: https://github.com/dollabs/plan-schema/compare/0.2.18...HEAD

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 ;; the file LICENSE at the root of this distribution.
 
 (def project 'dollabs/plan-schema)
-(def version "0.2.17")
+(def version "0.2.18")
 (def description "Temporal Planning Network schema utilities")
 (def project-url "https://github.com/dollabs/plan-schema")
 (def main 'plan-schema.cli)
@@ -27,7 +27,7 @@
                     [org.clojure/tools.nrepl     "0.2.12"         :scope "test"]
                     [adzerk/boot-reload          "0.5.1"          :scope "test"]
                     [pandeiro/boot-http          "0.7.6"          :scope "test"]
-                    [adzerk/boot-cljs            "2.0.0"          :scope "test"]
+                    [adzerk/boot-cljs            "1.7.228-2"      :scope "test"]
                     [adzerk/boot-cljs-repl       "0.3.3"          :scope "test"]
                     ;; testing/development
                     [adzerk/boot-test            "1.2.0"          :scope "test"]

--- a/src/plan_schema/core.cljc
+++ b/src/plan_schema/core.cljc
@@ -887,7 +887,7 @@
   {:added "0.1.0"}
   [network-type options]
   (let [{:keys [verbose file-format input output cwd]} options
-        _ (println "Reading input from:" input)
+        ;; _ (println "Reading input from:" input)
         verbose? (and (not (nil? verbose)) (pos? verbose))
         input (validate-input (if (vector? input) (first input) input) cwd)
         data #?(:clj (if (:error input) input (slurp input))
@@ -898,7 +898,7 @@
                  (read-json-str data)
                  #?(:clj (read-string data)
                     :cljs "not implemented yet")))
-        ;_ (println "DEBUG DATA\n" (with-out-str (pprint data)))
+        ;;_ (println "DEBUG DATA\n" (with-out-str (pprint data)))
         result (if (:error data)
                  data
                  (if (= network-type :htn)
@@ -907,7 +907,7 @@
                    #_(coerce-tpn data)
                    (records/coerce data))
                  )
-        ;_ (println "DEBUG RESULT\n" (with-out-str (pprint result)))
+        ;;_ (println "DEBUG RESULT\n" (with-out-str (pprint result)))
         out (if (:error result)
               result
               (if (su/error? result)
@@ -1248,8 +1248,8 @@
       (doseq [constraint constraints]
         (add-tpn-edge plans plan-id network-plid-id constraint
           from-plid-id to-id net)))
-    (if (not (keyword? to-id))
-      (log-debug "NOT KEYWORD TO-ID" to-id))
+    ;; (if (not (keyword? to-id))
+    ;;   (log-debug "NOT KEYWORD TO-ID" to-id))
     (add-tpn-node plans plan-id network-plid-id to-id net)
     ;; FIXME handle network-flows non-primitive
     nil))
@@ -1385,8 +1385,8 @@
       assoc network-plid-id network)
     (swap! plans update-in [:plan/by-plid plan-id :plan/networks]
       conj network-plid-id)
-    (if (not (keyword? begin-node))
-      (log-debug "NOT KEYWORD BEGIN-NODE" begin-node))
+    ;; (if (not (keyword? begin-node))
+    ;;   (log-debug "NOT KEYWORD BEGIN-NODE" begin-node))
     (add-tpn-node plans plan-id network-plid-id begin-node net)
     ;; create *-end pointer
     (let [nodes (:network/nodes
@@ -1403,8 +1403,9 @@
           ;; (log-debug "NODE-ID" node-id "END" end "NODE" node)
           (if-not (empty? end-node)
             (update-node plans (assoc end-node :node/begin node-id))
-            (if end
-              (log-debug "END NODE" end "NOT FOUND?")))))
+            ;; (if end
+            ;;   (log-debug "END NODE" end "NOT FOUND?"))
+            )))
       (when find-end?
         (swap! plans assoc-in [:network/network-by-plid-id
                                network-plid-id :network/end]


### PR DESCRIPTION
Reverted boot-cljs back to "1.7.228-2" to avoid JDK 8 dependency.
  * Closes #26 

Removed superfluous debugging messages
  * Closes PLANVIZ # 80 state end-node

Signed-off-by: Tom Marble <tmarble@info9.net>