### PR TITLE
Added coercion support for additional keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file. This change
 Changes
 * _TBD_
 
+### [0.3.3] - 2017-05-11
+
+Changes
+* Added coercion support for additional keys: :sequence-end :sequence-label :label
+  :between :between-starts :between-ends
+* Ensure coerced submaps are also in sorted order
+
 ### [0.3.2] - 2017-05-05
 
 Changes
@@ -192,4 +199,5 @@ Added
 [0.3.0]: https://github.com/dollabs/plan-schema/compare/0.2.18...0.3.0
 [0.3.1]: https://github.com/dollabs/plan-schema/compare/0.3.0...0.3.1
 [0.3.2]: https://github.com/dollabs/plan-schema/compare/0.3.1...0.3.2
-[Unreleased]: https://github.com/dollabs/plan-schema/compare/0.3.2...HEAD
+[0.3.3]: https://github.com/dollabs/plan-schema/compare/0.3.2...0.3.3
+[Unreleased]: https://github.com/dollabs/plan-schema/compare/0.3.3...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ Changes
 ### [0.3.3] - 2017-05-11
 
 Changes
-* Added coercion support for additional keys: :sequence-end :sequence-label :label
-  :between :between-starts :between-ends
+* Added coercion support for additional keys: :sequence-end :sequence-label
+  :label :between :between-starts :between-ends :display-name :args
 * Ensure coerced submaps are also in sorted order
+* Split out common functions to a new utils namespace (esp. logging)
+* Now the coerce namespace has converted println statements to logging
+  (note: the wrapping application should make a calls to initialize
+  logging as is done in #'planviz.server/log-initialize)
 
 ### [0.3.2] - 2017-05-05
 

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 ;; the file LICENSE at the root of this distribution.
 
 (def project 'dollabs/plan-schema)
-(def version "0.3.2")
+(def version "0.3.3")
 (def description "Temporal Planning Network schema utilities")
 (def project-url "https://github.com/dollabs/plan-schema")
 (def main 'plan-schema.cli)

--- a/src/plan_schema/cli.clj
+++ b/src/plan_schema/cli.clj
@@ -122,7 +122,7 @@
 (defn plan-schema
   "plan-schema command line processor. (see usage for help)."
   {:added "0.1.0"
-   :version "0.1.0"}
+   :version "0.3.3"}
   [& args]
   (let [{:keys [options arguments errors summary]}
         (parse-opts args cli-options)

--- a/src/plan_schema/coerce.clj
+++ b/src/plan_schema/coerce.clj
@@ -8,6 +8,22 @@
   (:require [clojure.set :as set]
             [clojure.pprint :refer [pprint]]))
 
+
+(defn sort-map
+  "Ensures that it an all values which are maps are in sorted order"
+  {:added "0.3.3"}
+  ([v]
+   (cond
+     (map? v)
+     (into (sorted-map) (reduce-kv sort-map {} v))
+     :else v))
+  ([m k v]
+   (assoc m k
+     (cond
+       (map? v)
+       (into (sorted-map) (reduce-kv sort-map {} v))
+       :else v))))
+
 ; TODO network and network-id serve the same purpose.
 ; Consider network-id deprecated and removed in future.
 ; TODO :type and :tpn-type serve the same purpose.
@@ -61,6 +77,21 @@
 (defmethod convert-property :end-node [key value]
   (to-keyword key value))
 
+(defmethod convert-property :sequence-end [key value]
+  (to-keyword key value))
+
+(defmethod convert-property :sequence-label [key value]
+  (to-keyword key value))
+
+(defmethod convert-property :between [key value]
+  (to-vector-of-keywords key value))
+
+(defmethod convert-property :between-starts [key value]
+  (to-vector-of-keywords key value))
+
+(defmethod convert-property :between-ends [key value]
+  (to-vector-of-keywords key value))
+
 (defmethod convert-property :controllable [key value]
   (to-boolean key value))
 
@@ -68,8 +99,11 @@
   (to-set-of-keywords key value))
 
 (defmethod convert-property :label [key value]
-  ;(println "Warning: Verify me" key "->" value);TODO
-  {key value})
+  ;; NOW using :label as a PAMELA label per Name Harmonization
+  ;; WAS
+  ;;(println "Warning: Verify me" key "->" value);TODO
+  ;; {key value})
+  (to-keyword key value))
 
 (defmethod convert-property :name [key value]
   {key value})
@@ -127,34 +161,34 @@
 (defmethod convert-property :plant-part [key value]
   (to-keyword key value))
 
-;;;
-; TODO label is reserved for pamela label semantics. Here label should be display-name?
-(def delay-activity-slots #{:uid :tpn-type :name :htn-node :constraints :label :controllable :end-node})
-(def activity-slots #{:uid :tpn-type :name :htn-node :constraints :label :controllable :end-node :args :argsmap :command :display-name}) ;FIXME :args-mapping
-(def activity-slots-optional #{:interface :plantid :plant-part}) ;FIXME :args-mapping
+(def delay-activity-slots #{:uid :tpn-type :name :htn-node :constraints :label :display-name :controllable :end-node})
+(def activity-slots #{:uid :tpn-type :name :htn-node :constraints :controllable :end-node :args :argsmap :command}) ;FIXME :args-mapping
+(def activity-slots-optional #{:interface :plantid :plant-part :label :display-name}) ;FIXME :args-mapping
 (def null-activity-slots #{:constraints :uid :tpn-type :end-node})
 (def state-slots #{:uid :tpn-type :constraints :activities :incidence-set})
-(def state-slots-optional #{:end-node :htn-node})
+(def state-slots-optional #{:end-node :htn-node :sequence-label :sequence-end})
 (def temporal-constraint-slots #{:uid :tpn-type :value :end-node})
 (def network-slots #{:uid :tpn-type :begin-node :end-node})
+;; NOTE a begin nodes *may* also begin a sequence and, if so, the :sequence-end key
+;; will be present
 (def begin-slots #{:constraints :uid :tpn-type :htn-node :end-node :activities :incidence-set})
 (def end-slots #{:constraints :uid :tpn-type :activities :incidence-set})
 
 
 ; HTN slots
-(def htn-network-slots #{:uid :type :label :rootnodes})
+(def htn-network-slots #{:uid :type :rootnodes})
 (def htn-network-slots-optional #{:display-name})
 
-(def htn-expanded-nonprimitive-task-slots #{:uid :type :label :incidence-set :edges})
+(def htn-expanded-nonprimitive-task-slots #{:uid :type :incidence-set :edges})
 (def htn-expanded-nonprimitive-task-slots-optional #{:name :display-name})
 
-(def htn-expanded-method-slots #{:uid :type :label :network :incidence-set :edges})
+(def htn-expanded-method-slots #{:uid :type :network :incidence-set :edges})
 (def htn-expanded-method-slots-optional #{:display-name})
 
 (def edge-slots #{:uid :type :end-node})
-(def edge-slots-optional #{:label :edge-type})
+(def edge-slots-optional #{:display-name :edge-type})
 
-(def htn-primitive-task-slots #{:uid :name :type :label :display-name :incidence-set :edges})
+(def htn-primitive-task-slots #{:uid :name :type :display-name :incidence-set :edges})
 (def htn-primitive-task-slots-optional #{:args :argsmap :interface :plantid :plant-part})
 
 ; Check for nil values
@@ -262,8 +296,14 @@
 
 ;;; Top level dispatch ;;;
 (defmulti convert "Function to dispatch coercion of top level scalars or maps of HTN and TPN"
-          (fn [key value]
-            (if (map? value) :map :scalar)))
+  (fn [key value]
+    (cond
+      (map? value)
+      :map
+      ;; (vector? value)
+      ;; :vector
+      :else
+      :scalar)))
 
 (defmethod convert :default [key value]
   (println "Warning: plan-schema convert" key " -> " value)
@@ -277,13 +317,19 @@
 (defmethod convert :map [outer-key m]
   ;(println "Converting map")
   (check-object m)
-  {outer-key (reduce (fn [result [key value]]
-                       (check-value-nil? key value)
-                       (conj result (convert-property key value))) {} m)})
+  {outer-key
+   (reduce (fn [result [key value]]
+             (check-value-nil? key value)
+             (conj result (convert-property key value))) {} m)})
+
+;; (defmethod convert :vector [key value]
+;;   ;(println "Converting vector" key value)
+;;   (check-value-nil? key value)
+;;   (mapv #(convert-property key %)) value)
 
 (defn coerce [data]
-  (reduce (fn [result [key value]]
-            ;(pprint result)
-            ;(println key " -> " value "-- done")
-
-            (conj result (convert key value))) {} data))
+  (sort-map
+    (reduce (fn [result [key value]]
+              ;; (pprint result)
+              ;; (println key " -> " value "-- done")
+              (conj result (convert key value))) {} data)))

--- a/src/plan_schema/core.clj
+++ b/src/plan_schema/core.clj
@@ -8,7 +8,7 @@
   "Temporal Planning Network schema utilities"
   (:require [clojure.string :as string]
             [clojure.set :as set]
-            [plan-schema.coerce :as records]
+            [plan-schema.coerce :as records :refer [sort-map]]
             [clojure.data.json :as json]
             [clojure.pprint :refer [pprint]]
             [avenir.utils :as au
@@ -78,7 +78,7 @@
           (json/read-str s)))
 
 (defn write-json-str [m]
-  (with-out-str (json/pprint (into (sorted-map) m))))
+  (with-out-str (json/pprint (sort-map m))))
 
 ;; TPN-------------------------------------------------------------------
 
@@ -899,7 +899,7 @@
               result
               (if (su/error? result)
                 {:error (with-out-str (println (:error result)))}
-                (into (sorted-map) result)))
+                (sort-map result)))
         out-json-str (if (= file-format :json)
                        (write-json-str out))
         output (validate-output output cwd)]
@@ -1722,8 +1722,8 @@
       ;; cross link here
       (link-htn-nodes-to-tpn-nodes htn-plan tpn-plan)
       (complete-tpn-selections htn-plan tpn-plan)
-      [(into (sorted-map) @htn-plan)
-       (into (sorted-map) @tpn-plan)])))
+      [(sort-map @htn-plan)
+       (sort-map @tpn-plan)])))
 
 ;; returns a plan map on success or :error on failure
 (defn tpn-plan
@@ -1752,7 +1752,7 @@
         _ (if-not error
             (add-plan tpn-plan :tpn-network (name->id tpn-name) tpn-name tpn))
         out (or error
-              (into (sorted-map) @tpn-plan))
+              (sort-map @tpn-plan))
         out-json-str (if (= file-format :json)
                        (write-json-str out))
         output (validate-output output cwd)]
@@ -1786,7 +1786,7 @@
         _ (if-not error
             (add-plan htn-plan :htn-network (name->id htn-name) htn-name htn))
         out (or error
-              (into (sorted-map) @htn-plan))
+              (sort-map @htn-plan))
         out-json-str (if (= file-format :json)
                        (write-json-str out))
         output (validate-output output cwd)]

--- a/src/plan_schema/utils.clj
+++ b/src/plan_schema/utils.clj
@@ -1,0 +1,109 @@
+;; Copyright © 2016 Dynamic Object Language Labs Inc.
+;;
+;; This software is licensed under the terms of the
+;; Apache License, Version 2.0 which can be found in
+;; the file LICENSE at the root of this distribution.
+
+(ns plan-schema.utils
+  "Temporal Planning Network schema utilities"
+  (:require [clojure.string :as string]
+            [clojure.set :as set]
+            [clojure.data.json :as json]
+            [clojure.pprint :refer [pprint]]
+            [avenir.utils :as au
+             :refer [keywordize assoc-if concatv]]
+            [me.raynes.fs :as fs]))
+
+
+(defn sort-map
+  "Ensures that it an all values which are maps are in sorted order"
+  {:added "0.3.3"}
+  ([v]
+   (cond
+     (map? v)
+     (into (sorted-map) (reduce-kv sort-map {} v))
+     :else v))
+  ([m k v]
+   (assoc m k
+     (cond
+       (map? v)
+       (into (sorted-map) (reduce-kv sort-map {} v))
+       :else v))))
+
+(defn synopsis [s]
+  (let [max-len 256
+        s (if (string? s) s (str s))]
+    (if (> (count s) max-len)
+      (str (subs s 0 max-len) " ...")
+      s)))
+
+(def configuration (atom {:strict false
+                          :loggers {}}))
+
+(defn strict? []
+  (:strict @configuration))
+
+(defn set-strict! [strict]
+  (swap! configuration assoc :strict strict))
+
+;; log-fn should take variable arity
+(defn set-logger! [level log-fn]
+  (swap! configuration assoc-in [:loggers level] log-fn))
+
+(defn logger [level & msgs]
+  (let [log-fn (get-in @configuration [:loggers level])]
+    (if (fn? log-fn)
+      (apply log-fn msgs)
+      (println (string/upper-case (name level))
+        (string/join " " msgs)))))
+
+(defn log-trace [& msgs]
+  (apply logger :trace msgs))
+
+(defn log-debug [& msgs]
+  (apply logger :debug msgs))
+
+(defn log-info [& msgs]
+  (apply logger :info msgs))
+
+(defn log-warn [& msgs]
+  (apply logger :warn msgs))
+
+(defn log-error [& msgs]
+  (apply logger :error msgs))
+
+(defn as-keywords [m]
+  (reduce (fn [res [k v]]
+            (conj res {(keyword k) v}))
+          {} m))
+
+(defn read-json-str [s]
+  (reduce (fn [res [k v]]
+            (if (map? v)
+              (conj res {(keyword k) (as-keywords v)})
+              (conj res {(keyword k) v})))
+          {}
+          (json/read-str s)))
+
+(defn write-json-str [m]
+  (with-out-str (json/pprint (sort-map m))))
+
+(defn error?
+  "Returns error string from operation (or nil on success)"
+  {:added "0.3.1"}
+  [output]
+  (cond
+    (map? output)
+    (:error output)
+    (string? output) ;; assume it's JSON as a string
+    (:error (read-json-str output))
+    (nil? output)
+    "Output is nil."
+    :else
+    (str "Unknown output format type: " (type output))))
+
+(defn stdout-option?
+  "Returns true if the output file name is STDOUT"
+  {:added "0.1.0"}
+  [output]
+  (or (empty? output) (= output "-")))


### PR DESCRIPTION
Additional keys are now coerced correctly:
  :sequence-end :sequence-label :label
  :between :between-starts :between-ends

Also support the new (Name Harmonization) slot :display-name

Added the sort-map function to ensure coerced submaps are also
in sorted order (all, not just top, level keys).

Signed-off-by: Tom Marble <tmarble@info9.net>