### PR TITLE
Support for :cost and :reward slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file. This change
 Changes
 * _TBD_
 
+### [0.3.5] - 2017-06-24
+
+Changes
+* Added coercion support for additional keys: :cost :reward
+* Significant improvements to testing macro match-eval-out-err
+  - Support Java pattern matching options (e.g. :case-insensitive)
+  - Add invert matching option (returns opposite of match result)
+  - Prints first form to EVAL on STDOUT (to better track down
+    which part of the test passes or fails)
+* Added fs-basename and fs-dirname to utils
+
 ### [0.3.4] - 2017-06-23
 
 Changes
@@ -211,4 +222,6 @@ Added
 [0.3.1]: https://github.com/dollabs/plan-schema/compare/0.3.0...0.3.1
 [0.3.2]: https://github.com/dollabs/plan-schema/compare/0.3.1...0.3.2
 [0.3.3]: https://github.com/dollabs/plan-schema/compare/0.3.2...0.3.3
-[Unreleased]: https://github.com/dollabs/plan-schema/compare/0.3.3...HEAD
+[0.3.4]: https://github.com/dollabs/plan-schema/compare/0.3.3...0.3.4
+[0.3.5]: https://github.com/dollabs/plan-schema/compare/0.3.4...0.3.5
+[Unreleased]: https://github.com/dollabs/plan-schema/compare/0.3.5...HEAD

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 ;; the file LICENSE at the root of this distribution.
 
 (def project 'dollabs/plan-schema)
-(def version "0.3.4")
+(def version "0.3.5")
 (def description "Temporal Planning Network schema utilities")
 (def project-url "https://github.com/dollabs/plan-schema")
 (def main 'plan-schema.cli)
@@ -87,3 +87,12 @@
                '())]
     (apply (resolve 'app/-main) argv)
     identity))
+
+;; (deftask cider-boot
+;;   "Cider boot params task"
+;;   []
+;;   ;; (cider))
+;;   (comp
+;;     (cider)
+;;     (repl :server true)
+;;     (wait)))

--- a/src/plan_schema/coerce.clj
+++ b/src/plan_schema/coerce.clj
@@ -148,10 +148,16 @@
 (defmethod convert-property :plant-part [key value]
   (to-keyword key value))
 
+(defmethod convert-property :cost [key value]
+  {key value})
+
+(defmethod convert-property :reward [key value]
+  {key value})
+
 (def delay-activity-slots #{:uid :tpn-type :name :htn-node :constraints :controllable :end-node})
 (def delay-activity-slots-optional #{:label :display-name})
 (def activity-slots #{:uid :tpn-type :name :htn-node :constraints :controllable :end-node :args :argsmap :command}) ;FIXME :args-mapping
-(def activity-slots-optional #{:interface :plantid :plant-part :label :display-name}) ;FIXME :args-mapping
+(def activity-slots-optional #{:interface :plantid :plant-part :label :display-name :cost :reward}) ;FIXME :args-mapping
 (def null-activity-slots #{:constraints :uid :tpn-type :end-node})
 (def state-slots #{:uid :tpn-type :constraints :activities :incidence-set})
 (def state-slots-optional #{:end-node :htn-node :sequence-label :sequence-end})

--- a/src/plan_schema/core.clj
+++ b/src/plan_schema/core.clj
@@ -9,7 +9,7 @@
   (:require [clojure.string :as string]
             [clojure.set :as set]
             [plan-schema.coerce :as records]
-            [plan-schema.utils :refer [synopsis sort-map strict?
+            [plan-schema.utils :refer [synopsis sort-map strict? fs-basename
                                        error? stdout-option?
                                        read-json-str write-json-str
                                        log-trace log-debug log-info
@@ -767,13 +767,14 @@
 
 (def coerce-htn (coercion htn))
 
-;; takes filename as a string
+;; takes pathname as a string
 ;;       plantypes as a set of valid plantypes (strings)
 ;;       formats as a set of valid formats (strings)
 ;; returns true if filename matches
-(defn kind-filename? [filename plantypes formats]
-  (let [[format plantype] (reverse (string/split filename #"\."))]
-    (boolean (and (plantypes plantype) (formats format)))))
+(defn kind-filename? [pathname plantypes formats]
+  (let [basename (fs-basename pathname)
+        [format plantype] (reverse (string/split basename #"\."))]
+       (boolean (and (plantypes plantype) (formats format)))))
 
 (defn tpn-filename? [filename]
   (kind-filename? filename #{"tpn"} #{"json" "edn"}))

--- a/src/plan_schema/utils.clj
+++ b/src/plan_schema/utils.clj
@@ -12,8 +12,11 @@
             [clojure.pprint :refer [pprint]]
             [avenir.utils :as au
              :refer [keywordize assoc-if concatv]]
-            [me.raynes.fs :as fs]))
-
+            [me.raynes.fs :as fs])
+  (:import [java.io ;; for fs-file-name
+            File]
+           [java.util.regex ;; for match-eval-out-err
+            Pattern]))
 
 (defn sort-map
   "Ensures that it an all values which are maps are in sorted order"
@@ -112,3 +115,143 @@
   {:added "0.1.0"}
   [output]
   (or (empty? output) (= output "-")))
+
+;; This is a complement to me.raynes.fs and will return the
+;; basename of the file path as a string
+(defn fs-basename [path]
+  (let [file (if (= (type path) File) path (File. path))]
+    (.getName file)))
+
+;; This is a complement to me.raynes.fs and will return the
+;; dirname of the file path as a string
+(defn fs-dirname [path]
+  (let [file (if (= (type path) File) path (File. path))]
+    (or (.getParent file) ".")))
+
+;; This helper function fs-get-path will get the path for a file
+;; and, optionally, remove a prefix (if present)
+(defn fs-get-path [path & [prefix]]
+  (let [file (if (= (type path) File) path (File. path))
+        path (.getPath file)]
+    (if prefix
+      (string/replace path prefix "")
+      path)))
+
+;; The macro match-eval-out-err is intended for testing and
+;; really belongs in a separate library. Putting it in the plan-schema
+;; library proper allows this harness to be re-used in other PAMELA
+;; related projects without duplication.
+
+(def pattern-opts
+  {:canon-eq Pattern/CANON_EQ
+   :case-insensitive Pattern/CASE_INSENSITIVE
+   :comments Pattern/COMMENTS
+   :dotall Pattern/DOTALL
+   :literal Pattern/LITERAL
+   :multiline Pattern/MULTILINE
+   :unicode-case Pattern/UNICODE_CASE
+   :unix-lines Pattern/UNIX_LINES
+   :invert 1024})
+
+(defn pattern-flag? [flags flag]
+  (not (zero? (bit-and flags (get pattern-opts flag 0))  )))
+
+;; expanded version of re-pattern that can take options
+;; see also
+;; http://docs.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html
+;; :invert means invert the match (i.e. the string should NOT match the re)
+(defn re-pattern-opts [s & options]
+  (let [flags (reduce (fn [a b] (bit-or a (get pattern-opts b 0))) 0 options)]
+    (Pattern/compile s flags)))
+
+(def stdout-ignore nil)
+
+(def stderr-ignore nil)
+
+(def stdout-empty #"^$")
+
+(def stderr-empty #"^$")
+
+(def stderr-no-errors (re-pattern-opts "error" :case-insensitive :invert))
+
+;; out-expect should
+;;   nil if we don't care about matching stdout
+;;   #"regex" -- a string (converted to regex) or regex that stdout should match
+;;     NOTE newlines are stripped from stdout before the match such that
+;;     the expression '.*' will match across lines
+;; err-expect is analogous to out-expect, for stderr
+;; the return value is [rv out-match err-match]
+;; where
+;;    rv is the value of the evaluated body
+;;    out-match is true for a match (or if we don't care),
+;;       else it is an error string explaining the match failed
+;;    err-match is analogous to out-match, but for stderr
+
+(defmacro match-eval-out-err
+  "Evaluates exprs in a context in which *out* and *err* are bound to a fresh
+  StringWriter.  Prints *out* and *err* after execution."
+  [out-expect err-expect & body]
+  `(let [body# (println "  EVAL" (pr-str (first (quote ~body))))
+         out# (new java.io.StringWriter)
+         err# (new java.io.StringWriter)
+         [rv# out-str# err-str#]
+         (binding [*out* out#
+                   *err* err#]
+           (let [exception# (atom nil)
+                 raw-rv# (try
+                           ~@body
+                           (catch Throwable e#
+                             (reset! exception# (.getMessage e#))
+                             nil))
+                 raw-out# (str out#)
+                 raw-err# (str err#)
+                 except-err# (if @exception#
+                               (str "EXCEPTION:\n" @exception#
+                                 "\nERROR:\n" raw-err#)
+                               raw-err#)]
+             [raw-rv# raw-out# except-err#]))
+         out-pattern# (cond
+                        (nil? ~out-expect)
+                        nil
+                        (string? ~out-expect)
+                        (re-pattern ~out-expect) ;; promote to pattern
+                        (instance? java.util.regex.Pattern ~out-expect)
+                        ~out-expect
+                        :else
+                        nil)
+         out-flags# (if out-pattern# (.flags out-pattern#) 0)
+         out-inverted# (pattern-flag? out-flags# :invert)
+         out-rv# (or (not out-pattern#) ;; we don't care about out
+                   (if ((if out-inverted# not identity)
+                        (re-find out-pattern# out-str#))
+                     true ;; we have a match
+                     (str (if out-inverted#
+                            "stdout DID match inverted "
+                            "stdout did NOT match ")
+                       "'" ~out-expect "' ===\n"
+                       out-str# "\n===")))
+         err-pattern# (cond
+                        (nil? ~err-expect)
+                        nil
+                        (string? ~err-expect)
+                        (re-pattern ~err-expect) ;; promote to pattern
+                        (instance? java.util.regex.Pattern ~err-expect)
+                        ~err-expect
+                        :else
+                        nil)
+         err-flags# (if err-pattern# (.flags err-pattern#) 0)
+         err-inverted# (pattern-flag? err-flags# :invert)
+         err-rv# (or (not err-pattern#) ;; we don't care about err
+                   (if ((if err-inverted# not identity)
+                        (re-find err-pattern# err-str#))
+                     true ;; we have a match
+                     (str (if err-inverted#
+                            "stderr DID match inverted "
+                            "stderr did NOT match ")
+                       "'" ~err-expect "' ===\n"
+                       err-str# "\n===")))]
+     ;; DEBUG
+     ;; (println "OUT=>" out-str# "<=OUT")
+     ;; (println "ERR=>" err-str# "<=ERR")
+     ;; (println "MATCH?" err-pattern# "="(re-find err-pattern# err-str#))
+     [rv# out-rv# err-rv#]))

--- a/test/testing/plan_schema/cli.clj
+++ b/test/testing/plan_schema/cli.clj
@@ -11,16 +11,11 @@
             [environ.core :refer [env]]
             [me.raynes.fs :as fs]
             [plan-schema.core :as pschema]
-            [plan-schema.cli :as cli]))
-
-(defn fs-get-path [file & [prefix]]
-  (let [path (.getPath file)]
-    (if prefix
-      (string/replace path prefix "")
-      path)))
-
-;; (deftest testing-repl-mode-on
-;;   (is (= "cat" (:pager env))))
+            [plan-schema.cli :as cli]
+            [plan-schema.utils :refer [fs-get-path
+                                       match-eval-out-err stderr-no-errors
+                                       stdout-ignore stderr-ignore
+                                       stdout-empty stderr-empty]]))
 
 (deftest testing-plan-schema-cli
   (testing "testing-plan-schema-cli")
@@ -37,179 +32,248 @@
 
     ;; pass EDN ----------------------------
 
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" tpn "-f" "edn"
-                 "-o" "-"
-                 "tpn"))))
-    (is (= 0 (cli/plan-schema "-i" tpn "-f" "edn"
+    (is (= [0 true true]
+          (match-eval-out-err #"^\{:act-11" stderr-no-errors
+            (cli/plan-schema "-i" tpn "-f" "edn" "-o" "-" "tpn")
+            )))
+    (is (= [0 true true]
+          (match-eval-out-err stdout-empty stderr-no-errors
+            (cli/plan-schema "-i" tpn "-f" "edn"
                "-o" (fs-get-path (fs/file target-cli "main.tpn.edn") top-path)
-               "tpn")))
+               "tpn")
+            )))
 
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" htn "-f" "edn"
-                 "-o" "-"
-                 "htn"))))
-    (is (= 0 (cli/plan-schema "-i" htn "-f" "edn"
-               "-o" (fs-get-path (fs/file target-cli "main.htn.edn") top-path)
-               "htn")))
+    (is (= [0 true true]
+          (match-eval-out-err #"^\{:hedge-58" stderr-no-errors
+            (cli/plan-schema "-i" htn "-f" "edn" "-o" "-" "htn")
+            )))
+    (is (= [0 true true]
+          (match-eval-out-err stdout-empty stderr-no-errors
+            (cli/plan-schema "-i" htn "-f" "edn"
+              "-o" (fs-get-path (fs/file target-cli "main.htn.edn") top-path)
+              "htn")
+            )))
 
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" tpn "-f" "edn"
-                 "-o" "-"
-                 "tpn-plan"))))
-    (is (= 0 (cli/plan-schema "-i" tpn "-f" "edn"
-               "-o" (fs-get-path (fs/file target-cli "main2.tpn.edn") top-path)
-               "tpn-plan")))
+    (is (= [0 true true]
+          (match-eval-out-err #"^\{:edge/edge-by-plid-id" stderr-no-errors
+            (cli/plan-schema "-i" tpn "-f" "edn" "-o" "-" "tpn-plan")
+            )))
+    (is (= [0 true true]
+          (match-eval-out-err stdout-empty stderr-no-errors
+            (cli/plan-schema "-i" tpn "-f" "edn"
+              "-o" (fs-get-path (fs/file target-cli "main2.tpn.edn") top-path)
+              "tpn-plan")
+            )))
 
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" htn "-f" "edn"
-                 "-o" "-"
-                 "htn-plan"))))
-    (is (= 0 (cli/plan-schema "-i" htn "-f" "edn"
-               "-o" (fs-get-path (fs/file target-cli "main2.htn.edn") top-path)
-               "htn-plan")))
-
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" htn "-i" tpn "-f" "edn"
-                 "-o" "-"
-                 "merge"))))
-    (is (= 0 (cli/plan-schema "-i" htn "-i" tpn "-f" "edn"
-               "-o" (fs-get-path (fs/file target-cli "main.merge.edn") top-path)
-               "merge")))
-
-    ;; fail EDN --------------------------------------------------------
-
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
-                 "-o" "-"
-                 "tpn"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "bogus.tpn.edn") top-path)
-               "tpn")))
-
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
-                 "-o" "-"
-                 "htn"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "bogus.htn.edn") top-path)
-               "htn")))
-
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
-                 "-o" "-"
-                 "tpn-plan"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "bogus2.tpn.edn") top-path)
-               "tpn-plan")))
-
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
-                 "-o" "-"
-                 "htn-plan"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "bogus2.htn.edn") top-path)
-               "htn-plan")))
-
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.fred.edn" "-i" "bogus.tpn.edn"
-                 "-f" "json"
-                 "-o" "-"
-                 "merge"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.fred.edn" "-i" "bogus.tpn.edn"
-               "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "fail.merge.edn") top-path)
-               "merge")))
-
-    ;; pass JSON  --------------------------------------------------------
-
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" tpn "-f" "json"
-                 "-o" "-"
-                 "tpn"))))
-    (is (= 0 (cli/plan-schema "-i" tpn "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "main.tpn.json") top-path)
-               "tpn")))
-
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" htn "-f" "json"
-                 "-o" "-"
-                 "htn"))))
-    (is (= 0 (cli/plan-schema "-i" htn "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "main.htn.json") top-path)
-               "htn")))
-
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" tpn "-f" "json"
-                 "-o" "-"
-                 "tpn-plan"))))
-    (is (= 0 (cli/plan-schema "-i" tpn "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "main2.tpn.json") top-path)
-               "tpn-plan")))
-
-    (is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" htn "-f" "json"
-                 "-o" "-"
-                 "htn-plan"))))
-    (is (= 0 (cli/plan-schema "-i" htn "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "main2.htn.json") top-path)
-               "htn-plan")))
+    (is (= [0 true true]
+          (match-eval-out-err #"^\{:edge/edge-by-plid-id" stderr-no-errors
+            (cli/plan-schema "-i" htn "-f" "edn" "-o" "-" "htn-plan")
+            )))
+    (is (= [0 true true]
+          (match-eval-out-err stdout-empty stderr-no-errors
+            (cli/plan-schema "-i" htn "-f" "edn"
+              "-o" (fs-get-path (fs/file target-cli "main2.htn.edn") top-path)
+              "htn-plan")
+            )))
 
     ;; These tests are not applicable because
     ;; -- The merged output is derived from htn and tpn
     ;; --  the output of merge is used by planviz/om-next and
     ;; we have no need to go between json <--> edn for merged content.
-    ;(is (= 0 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-    ;           (cli/plan-schema "-i" htn "-i" tpn "-f" "json"
-    ;             "-o" "-"
-    ;             "merge"))))
-    ;(is (= 0 (cli/plan-schema "-i" htn "-i" tpn "-f" "json"
-    ;           "-o" (fs-get-path (fs/file target-cli "main.merge.json") top-path)
-    ;           "merge")))
+    ;; (is (= [0 true true]
+    ;;       (match-eval-out-err #"^\[\{:edge/edge-by-plid-id" stderr-no-errors
+    ;;         (cli/plan-schema "-i" htn "-i" tpn "-f" "edn" "-o" "-" "merge")
+    ;;         )))
+    ;; (is (= [0 true true]
+    ;;       (match-eval-out-err stdout-empty stderr-no-errors
+    ;;         (cli/plan-schema "-i" htn "-i" tpn "-f" "edn"
+    ;;           "-o" (fs-get-path (fs/file target-cli "main.merge.edn") top-path)
+    ;;           "merge")
+    ;;         )))
+
+    ;; fail EDN --------------------------------------------------------
+
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.tpn.edn"
+            (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "edn" "-o" "-" "tpn")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.tpn.edn"
+            (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "edn"
+              "-o" (fs-get-path (fs/file target-cli "bogus.tpn.edn") top-path)
+              "tpn")
+            )))
+
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.htn.edn"
+            (cli/plan-schema "-i" "bogus.htn.edn" "-f" "edn" "-o" "-" "htn")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.htn.edn"
+            (cli/plan-schema "-i" "bogus.htn.edn""-f" "edn"
+              "-o" (fs-get-path (fs/file target-cli "bogus.htn.edn") top-path)
+              "htn")
+            )))
+
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.tpn.edn"
+            (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "edn" "-o" "-"
+              "tpn-plan")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.tpn.edn"
+            (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "edn"
+              "-o" (fs-get-path (fs/file target-cli "bogus2.tpn.edn") top-path)
+              "tpn-plan")
+            )))
+
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.htn.edn"
+            (cli/plan-schema "-i" "bogus.htn.edn""-f" "edn" "-o" "-" "htn-plan")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.htn.edn"
+            (cli/plan-schema "-i" "bogus.htn.edn""-f" "edn"
+              "-o" (fs-get-path (fs/file target-cli "bogus2.htn.edn") top-path)
+              "htn-plan")
+            )))
+
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "ERROR HTN file not one of:"
+            (cli/plan-schema "-i" "bogus.fred.edn" "-i" "bogus.tpn.edn"
+              "-f" "edn" "-o" "-" "merge")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "ERROR HTN file not one of:"
+            (cli/plan-schema "-i" "bogus.fred.edn" "-i" "bogus.tpn.edn"
+              "-f" "edn"
+              "-o" (fs-get-path (fs/file target-cli "incorrect.merge.edn") top-path)
+              "merge")
+            )))
+
+    ;; pass JSON  --------------------------------------------------------
+
+    (is (= [0 true true]
+          (match-eval-out-err #"^\"\{\\\"act-11\\\":" stderr-no-errors
+            (cli/plan-schema "-i" tpn "-f" "json" "-o" "-" "tpn")
+            )))
+    (is (= [0 true true]
+          (match-eval-out-err stdout-empty stderr-no-errors
+            (cli/plan-schema "-i" tpn "-f" "json"
+               "-o" (fs-get-path (fs/file target-cli "main.tpn.json") top-path)
+               "tpn")
+            )))
+
+    (is (= [0 true true]
+          (match-eval-out-err #"^\"\{\\\"hedge-58\\\":" stderr-no-errors
+            (cli/plan-schema "-i" htn "-f" "json" "-o" "-" "htn")
+            )))
+    (is (= [0 true true]
+          (match-eval-out-err stdout-empty stderr-no-errors
+            (cli/plan-schema "-i" htn "-f" "json"
+              "-o" (fs-get-path (fs/file target-cli "main.htn.json") top-path)
+              "htn")
+            )))
+
+    ;; NOTE: these tests are currently disabled as write-json-str
+    ;; does *not* preserve namespaced keywords
+    ;; (is (= [0 true true]
+    ;;       (match-eval-out-err #"^\"\{\\\"edge/edge-by-plid-id\\\":"
+    ;;         stderr-no-errors
+    ;;         (cli/plan-schema "-i" tpn "-f" "json" "-o" "-" "tpn-plan")
+    ;;         )))
+    ;; (is (= [0 true true]
+    ;;       (match-eval-out-err stdout-empty stderr-no-errors
+    ;;         (cli/plan-schema "-i" tpn "-f" "json"
+    ;;           "-o" (fs-get-path (fs/file target-cli "main2.tpn.json") top-path)
+    ;;           "tpn-plan")
+    ;;         )))
+
+    ;; (is (= [0 true true]
+    ;;       (match-eval-out-err #"^\"\{\\\"edge/edge-by-plid-id\\\":"
+    ;;         stderr-no-errors
+    ;;         (cli/plan-schema "-i" htn "-f" "json" "-o" "-" "htn-plan")
+    ;;         )))
+    ;; (is (= [0 true true]
+    ;;       (match-eval-out-err stdout-empty stderr-no-errors
+    ;;         (cli/plan-schema "-i" htn "-f" "json"
+    ;;           "-o" (fs-get-path (fs/file target-cli "main2.htn.json") top-path)
+    ;;           "htn-plan")
+    ;;         )))
+
+    ;; These tests are not applicable because
+    ;; -- The merged output is derived from htn and tpn
+    ;; --  the output of merge is used by planviz/om-next and
+    ;; we have no need to go between json <--> edn for merged content.
+    ;; (is (= [0 true true]
+    ;;       (match-eval-out-err #"^\"\[\{\\\"edge/edge-by-plid-id\\\":"
+    ;;         stderr-no-errors
+    ;;         (cli/plan-schema "-i" htn "-i" tpn "-f" "json" "-o" "-" "merge")
+    ;;         )))
+    ;; (is (= [0 true true]
+    ;;       (match-eval-out-err stdout-empty stderr-no-errors
+    ;;         (cli/plan-schema "-i" htn "-i" tpn "-f" "json"
+    ;;           "-o" (fs-get-path (fs/file target-cli "main.merge.json") top-path)
+    ;;           "merge")
+    ;;         )))
 
     ;; fail JSON  --------------------------------------------------------
 
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.tpn.edn"
+            (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json" "-o" "-" "tpn")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.tpn.edn"
+            (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
+              "-o" (fs-get-path (fs/file target-cli "bogus.tpn.edn") top-path)
+              "tpn")
+            )))
 
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
-                 "-o" "-"
-                 "tpn"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "bogus.tpn.json") top-path)
-               "tpn")))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.htn.edn"
+            (cli/plan-schema "-i" "bogus.htn.edn" "-f" "json" "-o" "-" "htn")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.htn.edn"
+            (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
+              "-o" (fs-get-path (fs/file target-cli "bogus.htn.edn") top-path)
+              "htn")
+            )))
 
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
-                 "-o" "-"
-                 "htn"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "bogus.htn.json") top-path)
-               "htn")))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.tpn.edn"
+            (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json" "-o" "-"
+              "tpn-plan")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.tpn.edn"
+            (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
+              "-o" (fs-get-path (fs/file target-cli "bogus2.tpn.edn") top-path)
+              "tpn-plan")
+            )))
 
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
-                 "-o" "-"
-                 "tpn-plan"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.tpn.edn" "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "bogus2.tpn.json") top-path)
-               "tpn-plan")))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.htn.edn"
+            (cli/plan-schema "-i" "bogus.htn.edn""-f" "json" "-o" "-" "htn-plan")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "input does not exist: bogus.htn.edn"
+            (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
+              "-o" (fs-get-path (fs/file target-cli "bogus2.htn.edn") top-path)
+              "htn-plan")
+            )))
 
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
-                 "-o" "-"
-                 "htn-plan"))))
-    (is (= 1 (cli/plan-schema "-i" "bogus.htn.edn""-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "bogus2.htn.json") top-path)
-               "htn-plan")))
-
-    (is (= 1 (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-               (cli/plan-schema "-i" htn "-i" "bogus.foo.json"
-                 "-f" "json"
-                 "-o" "-"
-                 "merge"))))
-    (is (= 1 (cli/plan-schema "-i" htn "-i" "bogus.foo.json"
-               "-f" "json"
-               "-o" (fs-get-path (fs/file target-cli "fail.merge.json") top-path)
-               "merge")))
-
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "ERROR HTN file not one of:"
+            (cli/plan-schema "-i" "bogus.fred.edn" "-i" "bogus.tpn.edn"
+              "-f" "json" "-o" "-" "merge")
+            )))
+    (is (= [1 true true]
+          (match-eval-out-err stdout-empty "ERROR HTN file not one of:"
+            (cli/plan-schema "-i" "bogus.fred.edn" "-i" "bogus.tpn.edn"
+              "-f" "json"
+              "-o" (fs-get-path (fs/file target-cli "incorrect.merge.edn") top-path)
+              "merge")
+            )))
     ))


### PR DESCRIPTION
* Added coercion support for additional keys: :cost :reward
* Significant improvements to testing macro match-eval-out-err
  - Support Java pattern matching options (e.g. :case-insensitive)
  - Add invert matching option (returns opposite of match result)
  - Prints first form to EVAL on STDOUT (to better track down
    which part of the test passes or fails)
* Added fs-basename and fs-dirname to utils

Signed-off-by: Tom Marble <tmarble@info9.net>